### PR TITLE
Fix section visibility conflict and restore login styles

### DIFF
--- a/apple-mobile.css
+++ b/apple-mobile.css
@@ -388,9 +388,7 @@
     display: none;
   }
   
-  /* Restaurar comportamiento original de secciones en desktop */
-  .section {
-    display: block !important; /* Forzar visibilidad en desktop */
-  }
+  /* Mantener comportamiento de secciones según clases */
+  /* Las reglas globales controlan la visibilidad */
 }
 

--- a/login-redesign.css
+++ b/login-redesign.css
@@ -1,0 +1,23 @@
+/* Additional tweaks for login modal redesign */
+
+.login-subtitle {
+  margin-bottom: var(--space-lg);
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.auth-toggle {
+  margin-top: var(--space-lg);
+  text-align: center;
+}
+
+.auth-toggle button {
+  background: none;
+  border: none;
+  color: var(--primary-200);
+  cursor: pointer;
+  font-weight: var(--font-weight-semibold);
+}
+
+.auth-toggle button:hover {
+  text-decoration: underline;
+}

--- a/missing_changes_analysis.py
+++ b/missing_changes_analysis.py
@@ -162,7 +162,36 @@ class MissingChangesAnalyzer:
                         'status': 'missing',
                         'reason': 'Elemento no presente en HTML'
                     }
-    
+
+    def analyze_missing_css_links(self):
+        """Analizar archivos CSS enlazados desde index.html"""
+        print("\n🎨 Analizando hojas de estilo enlazadas...")
+
+        if not os.path.exists('index.html'):
+            print("   ❌ index.html no encontrado")
+            return
+
+        with open('index.html', 'r', encoding='utf-8') as f:
+            html_content = f.read()
+
+        css_links = re.findall(r'href=\"(.+?\\.css)\"', html_content)
+
+        for css_file in css_links:
+            print(f"\n🔍 Verificando: {css_file}")
+
+            if os.path.exists(css_file):
+                print("   ✅ ENCONTRADO: Archivo CSS presente")
+                self.analysis_results[css_file] = {
+                    'status': 'found',
+                    'reason': 'Archivo CSS presente'
+                }
+            else:
+                print("   ❌ NO ENCONTRADO: Archivo CSS faltante")
+                self.analysis_results[css_file] = {
+                    'status': 'missing',
+                    'reason': 'Archivo CSS no existe'
+                }
+
     def analyze_missing_constants(self):
         """Analizar constantes faltantes"""
         print("\n📊 Analizando constantes faltantes...")
@@ -290,6 +319,7 @@ class MissingChangesAnalyzer:
         self.analyze_missing_files()
         self.analyze_missing_functions()
         self.analyze_missing_html_elements()
+        self.analyze_missing_css_links()
         self.analyze_missing_constants()
         
         recovery_rate = self.generate_analysis_report()

--- a/modern-login-styles.css
+++ b/modern-login-styles.css
@@ -1,0 +1,57 @@
+/* Styles for modernized login modal */
+
+/* Input container with icon */
+.input-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.input-icon {
+  position: absolute;
+  right: 1rem;
+  cursor: pointer;
+  color: rgba(255, 255, 255, 0.7);
+  transition: color 0.2s ease;
+}
+
+.input-icon:hover {
+  color: #ffffff;
+}
+
+.modern-input {
+  padding-right: 2.5rem;
+}
+
+.modern-login-btn {
+  width: 100%;
+  margin-top: var(--space-lg);
+}
+
+.forgot-password {
+  text-align: right;
+  margin-top: var(--space-sm);
+}
+
+.social-login {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  margin-top: var(--space-lg);
+}
+
+.btn-social {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+}
+
+.auth-divider {
+  text-align: center;
+  margin: var(--space-lg) 0;
+}
+
+.create-account-btn {
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- restore `modern-login-styles.css` and `login-redesign.css` links
- add placeholder stylesheets for the login modal
- remove desktop rule overriding section visibility in `apple-mobile.css`

## Testing
- `npm test` *(fails to load vitest config)*
- `pytest -q` *(fails: ModuleNotFoundError: backend_app)*

------
https://chatgpt.com/codex/tasks/task_b_68730ab096b08333944a643f8207790a