### PR TITLE
Add api client and validation utilities

### DIFF
--- a/apiClient.js
+++ b/apiClient.js
@@ -1,0 +1,50 @@
+export const API_BASE_URL = 'https://flashcard-u10n.onrender.com';
+
+/**
+ * Wrapper simplificado para realizar solicitudes HTTP
+ * @param {string} endpoint - Ruta relativa o URL absoluta
+ * @param {Object} [options={}] - Opciones de fetch
+ * @returns {Promise<Object>} - {success:boolean, data?:any, error?:string}
+ */
+export async function api(endpoint, options = {}) {
+  let url = endpoint.startsWith('http') ? endpoint : `${API_BASE_URL}${endpoint}`;
+  const { params, body, method = 'GET', headers = {}, ...rest } = options;
+
+  // Append query params if provided
+  if (params && typeof params === 'object') {
+    const searchParams = new URLSearchParams(params).toString();
+    if (searchParams) {
+      url += url.includes('?') ? `&${searchParams}` : `?${searchParams}`;
+    }
+  }
+
+  const isForm = body instanceof FormData;
+  const finalHeaders = { ...headers };
+  let finalBody = body;
+
+  if (body !== undefined && body !== null && !isForm) {
+    if (!finalHeaders['Content-Type']) {
+      finalHeaders['Content-Type'] = 'application/json';
+    }
+    finalBody = typeof body === 'string' ? body : JSON.stringify(body);
+  }
+
+  const config = { method, headers: finalHeaders, ...rest };
+  if (finalBody !== undefined) {
+    config.body = finalBody;
+  }
+
+  try {
+    const response = await fetch(url, config);
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      throw new Error(data.error || response.statusText);
+    }
+    return { success: true, data };
+  } catch (error) {
+    console.error('API request error:', error);
+    return { success: false, error: error.message };
+  }
+}
+
+export default { api };

--- a/utils/apiHelpers.js
+++ b/utils/apiHelpers.js
@@ -3,8 +3,8 @@
  * Elimina duplicación en llamadas API con fallback
  */
 
-import { ApiClient } from '';
-import { showNotification } from '';
+import { api } from '../apiClient.js';
+import { showNotification } from './helpers.js';
 
 /**
  * Realiza una llamada API con fallback a datos locales
@@ -21,7 +21,7 @@ export async function apiWithFallback(
   showFallbackMessage = true
 ) {
   try {
-    const data = await ApiClient.request(endpoint, options);
+    const data = await api(endpoint, options);
 
     // Si la API devuelve un error, usar fallback
     if (data && data.error) {
@@ -59,7 +59,7 @@ export async function multipleApiWithFallback(apiCalls) {
 
 /**
  * Wrapper para operaciones CRUD con manejo de errores estándar
- * @param {Function} operation - Función que realiza la operación (debe retornar una promesa con el resultado de ApiClient)
+ * @param {Function} operation - Función que realiza la operación (debe retornar una promesa con el resultado de api)
  * @param {string} successMessage - Mensaje de éxito
  * @param {string} errorMessage - Mensaje de error
  * @returns {Promise<any>} - Resultado de la operación
@@ -105,7 +105,7 @@ export async function loadDataWithRetry(
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      const result = await ApiClient.get(endpoint);
+      const result = await api(endpoint);
 
       if (result && !result.error) {
         return result.data;

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -1,0 +1,73 @@
+/**
+ * Validación genérica de campos requeridos
+ * @param {Object} data - Objeto con datos a validar
+ * @param {string[]} fields - Campos requeridos
+ * @returns {{isValid:boolean, errors:string[]}}
+ */
+export function validateRequiredFields(data, fields) {
+  const errors = [];
+  for (const field of fields) {
+    const value = data[field];
+    if (value === undefined || value === null || (typeof value === 'string' && !value.trim())) {
+      errors.push(`El campo ${field} es requerido`);
+    }
+  }
+  return { isValid: errors.length === 0, errors };
+}
+
+/**
+ * Valida datos de una flashcard
+ * @param {Object} data - Datos de la flashcard
+ * @param {boolean} [isUpdate=false] - Si es una actualización
+ * @param {Object} [config={}] - Configuración de validación
+ * @returns {{isValid:boolean, errors:string[]}}
+ */
+export function validateFlashcardData(data, isUpdate = false, config = {}) {
+  const {
+    maxTextLength = 5000,
+    supportedAlgorithms = ['fsrs', 'sm2', 'ultra_sm2', 'anki'],
+  } = config;
+
+  const errors = [];
+
+  if (!isUpdate && !data.deck_id) {
+    errors.push('deck_id es requerido');
+  }
+
+  const frontContent = data.front_content || {
+    text: data.front || data.front_text,
+    image_url: data.front_image_url,
+    audio_url: data.front_audio_url,
+  };
+
+  if (!frontContent.text && !frontContent.image_url && !frontContent.audio_url) {
+    errors.push('El contenido frontal debe tener al menos texto, imagen o audio');
+  }
+
+  const backContent = data.back_content || {
+    text: data.back || data.back_text,
+    image_url: data.back_image_url,
+    audio_url: data.back_audio_url,
+  };
+
+  if (!backContent.text && !backContent.image_url && !backContent.audio_url) {
+    errors.push('El contenido posterior debe tener al menos texto, imagen o audio');
+  }
+
+  if (frontContent.text && frontContent.text.length > maxTextLength) {
+    errors.push(`Texto frontal demasiado largo (máximo ${maxTextLength} caracteres)`);
+  }
+  if (backContent.text && backContent.text.length > maxTextLength) {
+    errors.push(`Texto posterior demasiado largo (máximo ${maxTextLength} caracteres)`);
+  }
+
+  if (data.difficulty && !['easy', 'normal', 'hard'].includes(data.difficulty)) {
+    errors.push('Dificultad debe ser: easy, normal o hard');
+  }
+
+  if (data.algorithm_type && !supportedAlgorithms.includes(data.algorithm_type)) {
+    errors.push(`Algoritmo no soportado. Opciones: ${supportedAlgorithms.join(', ')}`);
+  }
+
+  return { isValid: errors.length === 0, errors };
+}


### PR DESCRIPTION
## Summary
- implement `apiClient.js` with simple `api()` fetch wrapper
- create `utils/validation.js` for `validateFlashcardData` and helpers
- refactor `flashcards.service.js` to delegate validation to new util
- update `utils/apiHelpers.js` to use `api()`
- refactor service functions to call the new fetch wrapper

## Testing
- `npm test` *(fails: Could not resolve vitest config)*
- `npm run lint` *(fails: Unexpected string)*

------
https://chatgpt.com/codex/tasks/task_b_68732f3098b083338fe569d747aa5e65