### PR TITLE
Remove unused import

### DIFF
--- a/flashcards.service.js
+++ b/flashcards.service.js
@@ -7,7 +7,6 @@ import { api } from './apiClient.js';
 import { store } from './store.js';
 import { apiWithFallback, performCrudOperation } from './utils/apiHelpers.js';
 import { showNotification, generateId } from './utils/helpers.js';
-import { validateFlashcardData } from './utils/validation.js';
 
 /**
  * Configuración del servicio de flashcards


### PR DESCRIPTION
## Summary
- remove old `validateFlashcardData` import
- ensure validation calls use class method

## Testing
- `npm test` *(fails: Could not resolve "" in vitest.config.js)*

------
https://chatgpt.com/codex/tasks/task_b_68732f3c97708333a4ebb7491c2f3ede