### PR TITLE
Fix mobile menu toggle function

### DIFF
--- a/app-functional.js
+++ b/app-functional.js
@@ -294,7 +294,8 @@ class StudyingFlashApp {
         }
     }
 
-    loadDashboard() {     const mobileMenu = document.querySelector('.mobile-menu');
+    toggleMobileMenu() {
+        const mobileMenu = document.querySelector('.mobile-menu');
         if (mobileMenu) {
             mobileMenu.classList.toggle('active');
         }


### PR DESCRIPTION
## Summary
- add `toggleMobileMenu` method to handle mobile menu
- remove duplicate `loadDashboard` definition

## Testing
- `node scripts/enhanced_agent1_coordinator_fixed.cjs verifyStandards` *(fails: output truncated)*
- `npm test` *(fails to load vitest.config.js)*
- `pytest -q` *(fails: ModuleNotFoundError: backend_app)*

------
https://chatgpt.com/codex/tasks/task_b_68732c5f40808333ad0cabbce491914a