### PR TITLE
Fix section visibility via CSS classes

### DIFF
--- a/app-functional.js
+++ b/app-functional.js
@@ -239,14 +239,15 @@ class StudyingFlashApp {
     showSection(sectionName) {
         Utils.log(`Navegando a sección: ${sectionName}`);
         
-        // Ocultar todas las secciones con cssText completo
+        // Ocultar todas las secciones removiendo la clase 'active'
         document.querySelectorAll('.section').forEach(section => {
-            section.style.cssText = 'display: none !important;';
+            section.classList.remove('active');
         });
-        // Mostrar la sección solicitada con cssText completo
+
+        // Mostrar la sección solicitada añadiendo la clase 'active'
         const targetSection = document.getElementById(sectionName);
         if (targetSection) {
-            targetSection.style.cssText = 'display: block !important; visibility: visible !important; opacity: 1 !important;';
+            targetSection.classList.add('active');
             this.currentSection = sectionName;
             // Cargar contenido específico de la sección
             this.loadSectionContent(sectionName);


### PR DESCRIPTION
## Summary
- toggle `active` class instead of inline styles to show sections

## Testing
- `node scripts/enhanced_agent1_coordinator_fixed.cjs verifyStandards`
- `npm test` *(fails: vitest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: backend_app)*


------
https://chatgpt.com/codex/tasks/task_b_687342dd73a88333a23c93b4c2441ffb