### PR TITLE
Fix mobile menu toggle and login state

### DIFF
--- a/app-functional.js
+++ b/app-functional.js
@@ -293,17 +293,34 @@ class StudyingFlashApp {
                 Utils.log(`Sección ${sectionName} no tiene carga específica`);
         }
     }
-
-    loadDashboard() {     const mobileMenu = document.querySelector('.mobile-menu');
-        if (mobileMenu) {
-            mobileMenu.classList.toggle('active');
-        }
-    }
-
     closeMobileMenu() {
         const mobileMenu = document.querySelector('.mobile-menu');
         if (mobileMenu) {
             mobileMenu.classList.remove('active');
+        }
+    }
+
+    toggleMobileMenu() {
+        const mobileMenu = document.getElementById('mobile-menu');
+        const appleSidebar = document.getElementById('apple-sidebar');
+        const overlay = document.getElementById('apple-sidebar-overlay');
+        const menuBtn = document.getElementById('mobile-menu-btn');
+        const appleMenuBtn = document.getElementById('apple-menu-btn');
+
+        if (mobileMenu) {
+            mobileMenu.classList.toggle('active');
+        }
+        if (appleSidebar) {
+            appleSidebar.classList.toggle('active');
+        }
+        if (overlay) {
+            overlay.classList.toggle('active');
+        }
+        if (menuBtn) {
+            menuBtn.classList.toggle('active');
+        }
+        if (appleMenuBtn) {
+            appleMenuBtn.classList.toggle('active');
         }
     }
 
@@ -1167,6 +1184,7 @@ function showUserMenu() {
 
 function checkUserLogin() {
     const user = JSON.parse(localStorage.getItem('studyingflash_user') || '{}');
+    if (user && user.loggedIn) {
         updateUIForLoggedUser(user.email);
     }
 }


### PR DESCRIPTION
## Summary
- clean up duplicate `loadDashboard` definition
- add `toggleMobileMenu` method to manage mobile navigation
- update `checkUserLogin` to verify login state

## Testing
- `node scripts/enhanced_agent1_coordinator_fixed.cjs verifyStandards`
- `npm test` *(fails: could not resolve in vitest.config.js)*
- `pytest -q` *(fails: ModuleNotFoundError: backend_app)*

------
https://chatgpt.com/codex/tasks/task_b_687347fdee6c8333beb3c3a8430adf8c