### PR TITLE
Fix vitest import in navigation test

### DIFF
--- a/tests/unit/navigation.test.js
+++ b/tests/unit/navigation.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from '';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock DOM elements
 const mockElement = {


### PR DESCRIPTION
## Summary
- correct vitest utilities import in `navigation.test.js`

## Testing
- `node scripts/enhanced_agent1_coordinator_fixed.cjs verifyStandards`
- `npm test` *(fails: Could not resolve "" in vitest.config.js)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend_app')*

------
https://chatgpt.com/codex/tasks/task_b_6873480327708333b6dedb2fdf84fbdb