### PR TITLE
Fix duplicate dashboard method and add mobile menu toggle

### DIFF
--- a/app-functional.js
+++ b/app-functional.js
@@ -294,16 +294,23 @@ class StudyingFlashApp {
         }
     }
 
-    loadDashboard() {     const mobileMenu = document.querySelector('.mobile-menu');
-        if (mobileMenu) {
-            mobileMenu.classList.toggle('active');
-        }
-    }
-
+    /**
+     * Cierra el menú móvil si está abierto
+     */
     closeMobileMenu() {
         const mobileMenu = document.querySelector('.mobile-menu');
         if (mobileMenu) {
             mobileMenu.classList.remove('active');
+        }
+    }
+
+    /**
+     * Alterna la visibilidad del menú móvil
+     */
+    toggleMobileMenu() {
+        const mobileMenu = document.querySelector('.mobile-menu');
+        if (mobileMenu) {
+            mobileMenu.classList.toggle('active');
         }
     }
 


### PR DESCRIPTION
## Summary
- remove extraneous `loadDashboard` function
- add `toggleMobileMenu` and document mobile menu utilities
- keep dashboard loading logic

## Testing
- `node scripts/enhanced_agent1_coordinator_fixed.cjs verifyStandards`
- `npm test` *(fails: Could not resolve "" in vitest.config.js)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend_app')*

------
https://chatgpt.com/codex/tasks/task_b_687347e15890833394dbc979e692ed1d