### PR TITLE
Fix section toggle logic

### DIFF
--- a/app-functional.js
+++ b/app-functional.js
@@ -239,14 +239,15 @@ class StudyingFlashApp {
     showSection(sectionName) {
         Utils.log(`Navegando a sección: ${sectionName}`);
         
-        // Ocultar todas las secciones con cssText completo
+        // Ocultar todas las secciones quitando la clase activa
         document.querySelectorAll('.section').forEach(section => {
-            section.style.cssText = 'display: none !important;';
+            section.classList.remove('active');
         });
-        // Mostrar la sección solicitada con cssText completo
+
+        // Mostrar la sección solicitada agregando la clase activa
         const targetSection = document.getElementById(sectionName);
         if (targetSection) {
-            targetSection.style.cssText = 'display: block !important; visibility: visible !important; opacity: 1 !important;';
+            targetSection.classList.add('active');
             this.currentSection = sectionName;
             // Cargar contenido específico de la sección
             this.loadSectionContent(sectionName);


### PR DESCRIPTION
## Summary
- update `showSection` to toggle only the `active` class

## Testing
- `node scripts/enhanced_agent1_coordinator_fixed.cjs verifyStandards`
- `npm test` *(fails: Could not resolve "" in vitest.config.js)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend_app')*

------
https://chatgpt.com/codex/tasks/task_b_687347db59048333b687b4e98ad5746e